### PR TITLE
Did some code clean up

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,8 +113,8 @@ app.engine('handlebars', exphbs({
     defaultLayout: 'base',
     helpers: {
         prettyDate: function(start, end) {
-            var s = moment(start)
-            var e = moment(end)
+            var s = moment(new Date(start))
+            var e = moment(new Date(end))
             var format = 'Do MMM YYYY'
             if (s.year() != e.year()) {
                 return s.format(format) + " - " + e.format(format)
@@ -128,8 +128,8 @@ app.engine('handlebars', exphbs({
         },
 
         prettyDateTime: function(start, end) {
-          var s = moment(start)
-          var e = moment(end)
+          var s = moment(new Date(start))
+          var e = moment(new Date(end))
           var format = 'hh:mm a'
           return s.format(format) + " - " + e.format(format)
         }

--- a/routes/index.js
+++ b/routes/index.js
@@ -153,8 +153,6 @@ router.get('/events/international', function(req, res, next){
     // Sort Speakers by Last Name
     keynote = _.sortBy(keynote, ['Contact__r.LastName'])
     concurrent = _.sortBy(concurrent, ['Contact__r.LastName'])
-  })
-  .then(function(){
     res.render('conference/international', {
       layout: 'international',
       title: '29th International Conference - Shingo Institute',


### PR DESCRIPTION
### app.js
Wrapped the date strings being passed into the moment constructor with a JS Date constructor to suppress the deprecation warning from moment.

### routes/index.js
Removed the extraneous .then in the international route as it was semantically incorrect.